### PR TITLE
feat: Add Elimination Fouls selection on Add Game form

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.formatOnSave": true,
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true
+  },
+  "hide-files.files": []
+}

--- a/app/add/components/addGame.tsx
+++ b/app/add/components/addGame.tsx
@@ -11,9 +11,14 @@ import {
   useState,
 } from "react";
 
+const DEFAULT_TEAM_SCORING: TeamScoring = {
+  players: [],
+  score: 0,
+  eliminationFoul: "",
+};
 export default function AddGame({ allPlayers }: { allPlayers: PlayerMongo[] }) {
-  const [team2, setTeam2] = useState<TeamScoring>({ players: [], score: 0 });
-  const [team1, setTeam1] = useState<TeamScoring>({ players: [], score: 0 });
+  const [team2, setTeam2] = useState<TeamScoring>(DEFAULT_TEAM_SCORING);
+  const [team1, setTeam1] = useState<TeamScoring>(DEFAULT_TEAM_SCORING);
   const { isLoading, setIsLoading } = useUIStore((state) => state);
 
   const handleChangeTeam1Player = (
@@ -52,9 +57,30 @@ export default function AddGame({ allPlayers }: { allPlayers: PlayerMongo[] }) {
     setTeam2({ ...team2, score: parseInt(value) });
   };
 
+  const handleChangeEliminationFouls = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = e.target;
+    const [eliminationFoulType, team] = name.split("-");
+
+    if (team === "team1") {
+      setTeam1({
+        ...team1,
+        score: 0,
+        eliminationFoul: checked ? eliminationFoulType : "",
+      });
+      setTeam2({ ...team2, score: 1, eliminationFoul: "" });
+    } else {
+      setTeam2({
+        ...team2,
+        score: 0,
+        eliminationFoul: checked ? eliminationFoulType : "",
+      });
+      setTeam1({ ...team1, score: 1, eliminationFoul: " " });
+    }
+  };
+
   const handleReset: MouseEventHandler<HTMLButtonElement> = (e) => {
-    setTeam1({ players: [], score: 0 });
-    setTeam2({ players: [], score: 0 });
+    setTeam1(DEFAULT_TEAM_SCORING);
+    setTeam2(DEFAULT_TEAM_SCORING);
   };
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
@@ -154,6 +180,43 @@ export default function AddGame({ allPlayers }: { allPlayers: PlayerMongo[] }) {
           />
         </div>
 
+        <div className="collapse collapse-arrow  w-4/5 rounded-md">
+          <input type="checkbox" />
+          <div className="collapse-title font-medium">
+            🎱 - Elimination Fouls
+          </div>
+
+          <div className="collapse-content">
+            <div className="flex justify-between">
+              <div className="form-control flex justify-between flex-col items-center gap-4">
+                <label className="label cursor-pointer">
+                  <span className="label-text mr-2">Black</span>
+                  <input
+                    type="checkbox"
+                    className="checkbox"
+                    name="black-team1"
+                    checked={team1.eliminationFoul === "black"}
+                    onChange={handleChangeEliminationFouls}
+                  />
+                </label>
+              </div>
+
+              <div className="form-control flex flex-col items-center gap-4">
+                <label className="label cursor-pointer">
+                  <span className="label-text mr-2">Black</span>
+                  <input
+                    type="checkbox"
+                    className="checkbox"
+                    name="black-team2"
+                    checked={team2.eliminationFoul === "black"}
+                    onChange={handleChangeEliminationFouls}
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div className="flex justify-evenly">
           <div className="flex flex-col items-center gap-4">
             <span>Score team 1</span>
@@ -161,7 +224,7 @@ export default function AddGame({ allPlayers }: { allPlayers: PlayerMongo[] }) {
               className="input input-bordered w-1/2 focus:outline-accent"
               type="number"
               name="score"
-              defaultValue={team1.score}
+              value={team1.score}
               onChange={handleChangeTeam1Score}
             />
           </div>
@@ -172,7 +235,7 @@ export default function AddGame({ allPlayers }: { allPlayers: PlayerMongo[] }) {
               className="input input-bordered w-1/2 focus:outline-accent"
               type="number"
               name="score"
-              defaultValue={team2.score}
+              value={team2.score}
               onChange={handleChangeTeam2Score}
             />
           </div>

--- a/app/api/game/route.ts
+++ b/app/api/game/route.ts
@@ -38,8 +38,16 @@ export async function POST(request: Request) {
   );
 
   const newGame = await createGame({
-    team1: { players: team1Players, score: team1.score },
-    team2: { players: team2Players, score: team2.score },
+    team1: {
+      players: team1Players,
+      score: team1.score,
+      eliminationFoul: team1.eliminationFoul,
+    },
+    team2: {
+      players: team2Players,
+      score: team2.score,
+      eliminationFoul: team2.eliminationFoul,
+    },
   });
 
   const allPlayer = [...newGame.team1, ...newGame.team2];

--- a/modules/elo/types.ts
+++ b/modules/elo/types.ts
@@ -4,6 +4,7 @@ import { minimalPlayerSchema } from "../player/schemas";
 export const teamScoringSchema = z.object({
   players: z.array(minimalPlayerSchema),
   score: z.number(),
+  eliminationFoul: z.string(),
 });
 
 export type TeamScoring = z.infer<typeof teamScoringSchema>;

--- a/modules/game/constants.ts
+++ b/modules/game/constants.ts
@@ -1,0 +1,4 @@
+export const ELIMINATION_FOUL = {
+  BLACK: "black",
+  BLACK_AND_WHITE: "black_and_white",
+};

--- a/modules/game/create.ts
+++ b/modules/game/create.ts
@@ -1,8 +1,9 @@
 import mongooseConnect from "@/database/config/mongoose";
-import { TeamScoring } from "../elo/types";
 import { gameModel } from "./model";
 import { GameMongo } from "./types";
-import { playerToMinimalPlayer } from "./utils";
+import { TeamScoring } from "../elo/types";
+import { getEliminationFoul, playerToMinimalPlayer } from "./utils";
+import { ELIMINATION_FOUL } from "./constants";
 
 export const createGame = async ({
   team1,
@@ -12,10 +13,14 @@ export const createGame = async ({
   team2: TeamScoring;
 }): Promise<GameMongo> => {
   await mongooseConnect();
+
+  const eliminationFoul = getEliminationFoul([team1, team2]);
+
   return gameModel.create({
     team1: team1.players.map(playerToMinimalPlayer),
     team2: team2.players.map(playerToMinimalPlayer),
     scores: [team1.score, team2.score],
     winner: team1.score > team2.score ? "1" : "2",
+    ...(eliminationFoul !== null && { eliminationFoul }),
   });
 };

--- a/modules/game/model.ts
+++ b/modules/game/model.ts
@@ -23,6 +23,7 @@ const gameModelSchema = new Schema<GameMongo>(
       type: [minimalPlayerModelSchema],
       required: true,
     },
+    eliminationFoul: { type: String, required: false },
     scores: { type: [Number], required: true },
     winner: { type: String, enum: ["1", "2"], required: true },
   },

--- a/modules/game/schemas.ts
+++ b/modules/game/schemas.ts
@@ -7,6 +7,7 @@ export const gameSchema = z.object({
   team2: teamSchema,
   scores: z.array(z.number()).length(2),
   winner: z.enum(["1", "2"]),
+  eliminationFoul: z.string().optional(),
 });
 
 export const gameMongoSchema = baseMongoSchema.merge(gameSchema);

--- a/modules/game/utils.ts
+++ b/modules/game/utils.ts
@@ -1,4 +1,6 @@
 import { MinimalPlayer } from "../player/types";
+import { TeamScoring } from "../elo/types";
+import { ELIMINATION_FOUL } from "./constants";
 
 export const playerToMinimalPlayer = <T extends MinimalPlayer>(
   player: T
@@ -8,3 +10,13 @@ export const playerToMinimalPlayer = <T extends MinimalPlayer>(
   rating: player.rating,
   games: player.games,
 });
+
+export const getEliminationFoul = (teams: TeamScoring[]) => {
+  const teamWithEliminationFoul = teams.find((team) =>
+    Object.values(ELIMINATION_FOUL).includes(team.eliminationFoul)
+  );
+
+  return teamWithEliminationFoul
+    ? teamWithEliminationFoul.eliminationFoul
+    : null;
+};


### PR DESCRIPTION

We can select an elimination foul for a team when adding the result of a game If we select foul "black" it will fill score input with 1-0 for the winner.

![image](https://github.com/user-attachments/assets/65c22fbc-0d64-464c-91dc-35e927b97997)
