### PR TITLE
Fix game addition redirect in production

### DIFF
--- a/app/api/game/route.ts
+++ b/app/api/game/route.ts
@@ -77,11 +77,6 @@ export async function POST(request: Request) {
     (player) => player._id
   );
 
-  revalidatePath(`/[activityName]`, "layout");
-  for (const playerId of playerIds) {
-    revalidatePath(`/playerHistory/${playerId}`, "layout");
-  }
-
   const updatedPlayers = await Promise.all(
     newPlayersRatings.map((player) =>
       updatePlayerRating({
@@ -111,6 +106,11 @@ export async function POST(request: Request) {
       eliminationFoul: team2.eliminationFoul,
     },
   });
+
+  revalidatePath(`/[activityName]`, "layout");
+  for (const playerId of playerIds) {
+    revalidatePath(`/playerHistory/${playerId}`, "layout");
+  }
 
   const urlWithoutProtocol = join(getEnvConfigs().VERCEL_URL, "/api/quote");
   fetch(buildFullUrl(urlWithoutProtocol), {


### PR DESCRIPTION
Move revalidatePath calls after game creation and player ratings update to ensure data is persisted to database before cache invalidation. This fixes the issue where users had to manually refresh after adding a game to see the updated leaderboard.